### PR TITLE
Merge inline css patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /pm_to_blib
 /t/scripts
 /t/data/output.txt
+/.project

--- a/Changes
+++ b/Changes
@@ -2,6 +2,10 @@ Revision history for Perl extension SVN::Notify
 
 2.85
       - Fixed a typo, thanks to gregor herrmann of the Debian project.
+      - ColorDiff now outputs inline css by default, adding compatibily with
+        many web mail clients like gmail. Added by Fabrizio Giustina,
+        original patch by "teguheko" submitted through 
+        https://rt.cpan.org/Public/Bug/Display.html?id=52121
 
 2.84  2013-08-13T14:25:21Z
       - Added `--smtp-tls` to the output of `man svnnotify`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 SVN/Notify version 2.85
 =======================
 
+    patched with inline css support
+
 This class may be used for sending email messages for
 [Subversion](http://subversion.tigris.org/) repository activity. There are a
 number of different modes supported, and SVN::Notify is fully subclassable, to

--- a/lib/SVN/Notify/HTML.pm
+++ b/lib/SVN/Notify/HTML.pm
@@ -200,7 +200,7 @@ sub start_html {
                   qq{" />\n}
               ) : ()
         ),
-        '<title>', encode_entities($self->subject, '<>&"'),
+        '<title>', encode_entities($self->subject),
         qq{</title>\n</head>\n<body>\n\n}
     );
 
@@ -333,7 +333,7 @@ sub output_log_message {
         ?  join(
             "\n",
             @{ $self->run_filters( log_message => [ @{ $self->message } ] ) }
-        ) :  encode_entities( join( "\n", @{ $self->message } ), '<>&"');
+        ) :  encode_entities( join( "\n", @{ $self->message } ));
 
     # Turn URLs and email addresses into links.
     if ($self->linkize) {

--- a/lib/SVN/Notify/HTML.pm
+++ b/lib/SVN/Notify/HTML.pm
@@ -213,8 +213,7 @@ sub start_html {
 =head3 start_body
 
 This method starts the body of the HTML notification message. It first calls
-C<start_html()>, and then outputs the C<< <style> >> tag, calling
-C<output_css()> between them. It then outputs an opening C<< <div> >> tag.
+C<start_html()>. It then outputs an opening C<< <div> >> tag.
 
 If the C<header> attribute is set, C<start_body()> outputs it between
 C<< <div> >> tags with the ID "header". Furthermore, if the header happens to
@@ -232,9 +231,6 @@ Filters|SVN::Notify/"Writing Output Filters"> for details on filters.
 sub start_body {
     my ($self, $out) = @_;
     $self->start_html($out);
-    print $out qq{<style type="text/css"><!--\n};
-    $self->output_css( $out );
-    print $out qq{--></style>\n};
 
     my @html = ( (qq{<div id="msg" style="color:black;">\n}) );
     if (my $header = $self->header) {
@@ -249,30 +245,6 @@ sub start_body {
     return $self;
 }
 
-##############################################################################
-
-=head3 output_css
-
-  $notifier->output_css($file_handle);
-
-This method starts outputs the CSS for the HTML message. It is called by
-C<start_body()>, and which wraps the output of C<output_css()> in the
-appropriate C<< <style> >> tags.
-
-An output filter named "css" may be added to modify the output of CSS. The
-filter subroutine name should be C<css> and expect an array reference of lines
-of CSS. See L<Writing Output Filters|SVN::Notify/"Writing Output Filters"> for
-details on filters.
-
-=cut
-
-sub output_css {
-    my ($self, $out) = @_;
-    # We use _css() so that ColorDiff can override it and the filters then
-    # applied only one to all of the CSS.
-    print $out @{ $self->run_filters( css => $self->_css ) };
-    return $self;
-}
 
 ##############################################################################
 

--- a/lib/SVN/Notify/HTML.pm
+++ b/lib/SVN/Notify/HTML.pm
@@ -236,10 +236,10 @@ sub start_body {
     $self->output_css( $out );
     print $out qq{--></style>\n};
 
-    my @html = ( qq{<div id="msg">\n} );
+    my @html = ( (qq{<div id="msg" style="color:black;">\n}) );
     if (my $header = $self->header) {
         push @html, (
-            '<div id="header">',
+            ( '<div id="header" style="color: #fff; background: #636; border: 1px #300 solid; padding: 6px;font-family: verdana,arial,helvetica,sans-serif; font-size: 10pt; ">'),
             ( $header =~ /^</  ? $header : encode_entities($header, '<>&"') ),
             "</div>\n",
         );
@@ -298,24 +298,26 @@ sub output_metadata {
         return $self->SUPER::output_metadata($out);
     }
 
-    print $out qq{<dl class="meta">\n<dt>Revision</dt> <dd>};
-
+    print $out ( (
+        qq{<dl class="meta" style="border: 1px #006 solid; background: #369; padding: 6px; color: #fff; font-family: verdana,arial,helvetica,sans-serif; font-size: 10pt;">\n},
+        qq{<dt style="float: left; width: 6em; font-weight: bold;font-family: verdana,arial,helvetica,sans-serif; font-size: 10pt;">Revision:</dt> <dd>}
+    ));
     my $rev = $self->revision;
     if (my $url = $self->revision_url) {
         $url = encode_entities($url, '<>&"');
         # Make the revision number a URL.
-        printf $out qq{<a href="$url">$rev</a>}, $rev;
+        printf $out ( qq{<a style="color: white;font-weight: bold;" href="$url">$rev</a>} ), $rev;
     } else {
         # Just output the revision number.
         print $out $rev;
     }
 
     # Output the committer and a URL, if there is one.
-    print $out "</dd>\n<dt>Author</dt> <dd>";
+    print $out ( qq{</dd>\n<dt style="float: left; width: 6em; font-weight: bold;font-family: verdana,arial,helvetica,sans-serif; font-size: 10pt;">Author:</dt> <dd>} );
     my $user = encode_entities($self->user, '<>&"');
     if (my $url = $self->author_url) {
         $url = encode_entities($url, '<>&"');
-        printf $out qq{<a href="$url">$user</a>}, $user;
+        printf $out ( qq{<a style="color: white;font-weight: bold" href="$url">$user</a>} ), $user;
     } else {
         # Just output the username
         print $out $user;
@@ -323,7 +325,7 @@ sub output_metadata {
 
     print $out (
         "</dd>\n",
-        '<dt>Date</dt> <dd>',
+        ( qq{<dt style="float: left; width: 6em; font-weight: bold;font-family: verdana,arial,helvetica,sans-serif; font-size: 10pt;">Date:</dt> <dd>} ),
         encode_entities($self->date, '<>&"'), "</dd>\n",
         "</dl>\n\n"
     );
@@ -392,15 +394,15 @@ sub output_log_message {
 
     print $out "<h3>Log Message</h3>\n";
     if ($filters || $self->wrap_log) {
-        $msg = '<p>' . join( "</p>\n\n<p>", split /\n\s*\n/, $msg ) . '</p>'
-            if !$filters && $self->wrap_log;
-        print $out (
-            qq{<div id="logmsg">\n},
-            $msg,
-            qq{</div>\n\n},
-        )
+        $msg = ( '<p style="margin: 0 0 1em 0;line-height: 14pt;">' . join( "</p>\n\n<p style=\"margin: 0 0 1em 0;line-height: 14pt;\">", split /\n\s*\n/, $msg ) . '</p>' )
+        if !$filters && $self->wrap_log;
+			print $out (
+				( qq{<div id="logmsg" style="background: #ffc; border: 1px #fa0 solid; padding: 0 1em 0 1em; font-family: verdana,arial,helvetica,sans-serif; font-size: 10pt;">\n} ),
+				$msg,
+				qq{</div>\n\n},
+			)
     } else {
-        print $out "<pre>$msg</pre>\n\n";
+        print $out ( qq{<pre style="overflow: auto; background: #ffc; border: 1px #fa0 solid; padding: 6px;">$msg</pre>\n\n} );
     }
     return $self;
 }
@@ -488,7 +490,7 @@ sub end_body {
     my @html;
     if (my $footer = $self->footer) {
         push @html, (
-            '<div id="footer">',
+            ( '<div id="footer" style="color: #fff; background: #636; border: 1px #300 solid; padding: 6px;font-family: verdana,arial,helvetica,sans-serif; font-size: 10pt; ">' ),
             ( $footer =~ /^</  ? $footer : encode_entities($footer, '<>&"') ),
             "</div>\n",
         );

--- a/lib/SVN/Notify/HTML.pm
+++ b/lib/SVN/Notify/HTML.pm
@@ -556,49 +556,6 @@ Gets or sets the value of the C<css_url> attribute.
 
 ##############################################################################
 
-sub _css {
-    return [
-        q(#msg dl.meta { border: 1px #006 solid; background: #369; ),
-            qq(padding: 6px; color: #fff; }\n),
-        qq(#msg dl.meta dt { float: left; width: 6em; font-weight: bold; }\n),
-        qq(#msg dt:after { content:':';}\n),
-        q(#msg dl, #msg dt, #msg ul, #msg li, #header, #footer, #logmsg { font-family: ),
-            qq(verdana,arial,helvetica,sans-serif; font-size: 10pt;  }\n),
-        qq(#msg dl a { font-weight: bold}\n),
-        qq(#msg dl a:link    { color:#fc3; }\n),
-        qq(#msg dl a:active  { color:#ff0; }\n),
-        qq(#msg dl a:visited { color:#cc6; }\n),
-        q(h3 { font-family: verdana,arial,helvetica,sans-serif; ),
-            qq(font-size: 10pt; font-weight: bold; }\n),
-        q(#msg pre { white-space: pre-line; overflow: auto; background: #ffc; ),
-            qq(border: 1px #fa0 solid; padding: 6px; }\n),
-        qq(#logmsg { background: #ffc; border: 1px #fa0 solid; padding: 1em 1em 0 1em; }\n),
-        qq(#logmsg p, #logmsg pre, #logmsg blockquote { margin: 0 0 1em 0; }\n),
-        qq(#logmsg p, #logmsg li, #logmsg dt, #logmsg dd { line-height: 14pt; }\n),
-        qq(#logmsg h1, #logmsg h2, #logmsg h3, #logmsg h4, #logmsg h5, #logmsg h6 { margin: .5em 0; }\n),
-        qq(#logmsg h1:first-child, #logmsg h2:first-child, #logmsg h3:first-child, #logmsg h4:first-child, #logmsg h5:first-child, #logmsg h6:first-child { margin-top: 0; }\n),
-        qq{#logmsg ul, #logmsg ol { padding: 0; list-style-position: inside; margin: 0 0 0 1em; }\n},
-        qq{#logmsg ul { text-indent: -1em; padding-left: 1em; }},
-        qq{#logmsg ol { text-indent: -1.5em; padding-left: 1.5em; }\n},
-        qq(#logmsg > ul, #logmsg > ol { margin: 0 0 1em 0; }\n),
-        qq(#logmsg pre { background: #eee; padding: 1em; }\n),
-        qq(#logmsg blockquote { border: 1px solid #fa0; border-left-width: 10px; padding: 1em 1em 0 1em; background: white;}\n),
-        qq(#logmsg dl { margin: 0; }\n),
-        qq(#logmsg dt { font-weight: bold; }\n),
-        qq(#logmsg dd { margin: 0; padding: 0 0 0.5em 0; }\n),
-        qq(#logmsg dd:before { content:'\\00bb';}\n),
-        qq(#logmsg table { border-spacing: 0px; border-collapse: collapse; border-top: 4px solid #fa0; border-bottom: 1px solid #fa0; background: #fff; }\n),
-        qq(#logmsg table th { text-align: left; font-weight: normal; padding: 0.2em 0.5em; border-top: 1px dotted #fa0; }\n),
-        qq(#logmsg table td { text-align: right; border-top: 1px dotted #fa0; padding: 0.2em 0.5em; }\n),
-        qq(#logmsg table thead th { text-align: center; border-bottom: 1px solid #fa0; }\n),
-        qq(#logmsg table th.Corner { text-align: left; }\n),
-        qq(#logmsg hr { border: none 0; border-top: 2px dashed #fa0; height: 1px; }\n),
-        q(#header, #footer { color: #fff; background: #636; ),
-        qq(border: 1px #300 solid; padding: 6px; }\n),
-        qq(#patch { width: 100%; }\n),
-    ];
-}
-
 1;
 __END__
 

--- a/lib/SVN/Notify/HTML/ColorDiff.pm
+++ b/lib/SVN/Notify/HTML/ColorDiff.pm
@@ -104,7 +104,7 @@ sub output_diff {
         next unless $line;
         if ( $max && ( $length += length $line ) >= $max ) {
             print $out "</$in_span>" if $in_span;
-            print $out qq{<span class="lines">\@\@ Diff output truncated at $max characters. \@\@\n</span>};
+            print $out ( qq{<span class="lines" style="display:block;padding:0 10px;color:#888;background:#fff;">\@\@ Diff output truncated at $max characters. \@\@\n</span>} );
             $in_span = '';
             last;
         } else {
@@ -121,8 +121,8 @@ sub output_diff {
                 if (<$diff> !~ /^=/) {
                     # Looks like they used --no-diff-added or --no-diff-deleted.
                     ($in_span, $in_div) = '';
-                    print $out qq{<a id="$id"></a>\n<div class="$class">},
-                        qq{<h4>$action: $file</h4></div>\n};
+                    print $out ( ( qq{<a id="$id"></a>\n<div class="$class" style="border:1px solid #ccc;margin:10px 0;">},
+                          qq{<h4 style="font-family: verdana,arial,helvetica,sans-serif;font-size:10pt;padding:8px;background:#369;color:#fff;margin:0;">$action: $file</h4></div>\n}) );
                     next;
                 }
 
@@ -132,9 +132,13 @@ sub output_diff {
 
                 if ($before =~ /^\(Binary files differ\)/) {
                     # Just output the whole file div.
-                    print $out qq{<a id="$id"></a>\n<div class="binary"><h4>},
-                      qq{$action: $file</h4>\n<pre class="diff"><span>\n},
-                      qq{<span class="cx">$before\n</span></span></pre></div>\n};
+                    print $out (
+						( qq{<a id="$id"></a>\n<div class="binary" style="border:1px solid #ccc;margin:10px 0;"><h4 style="font-family: verdana,arial,helvetica,sans-serif;font-size:10pt;padding:8px;background:#369;color:#fff;margin:0;">},
+						  qq{$action: $file</h4>\n},
+						  qq{<pre class="diff" style="color:black;padding:0;line-height:1.2em;margin:0;width:100%;background:#eee;padding: 0 0 10px 0;overflow:auto;font-family:'Andale Mono','Courier New',monospace;font-size:9pt;">},
+						  qq{<span style="display:block;padding:0 10px;">\n},
+						  qq{<span style="display:block;padding:0 10px;">$before\n</span></span></pre></div>\n})
+                        )  ;
                     ($in_span, $in_div) = '';
                     next;
                 }
@@ -145,9 +149,11 @@ sub output_diff {
                 my ($rev2) = $after =~ /\(rev (\d+)\)$/;
 
                 # Output the headers.
-                print $out qq{<a id="$id"></a>\n<div class="$class"><h4>$action: $file},
-                  " ($rev1 => $rev2)</h4>\n";
-                print $out qq{<pre class="diff"><span>\n<span class="info">};
+                print $out ( ( qq{<a id="$id"></a>\n<div class="$class" style="border:1px solid #ccc;margin:10px 0;">},
+                          qq{<h4 style="font-family: verdana,arial,helvetica,sans-serif;font-size:10pt;padding:8px;background:#369;color:#fff;margin:0;">$action: $file},
+						  " ($rev1 => $rev2)</h4>\n") );
+                print $out ( ( qq{<pre class="diff" style="color:black;padding:0;line-height:1.2em;margin:0;width:100%;background:#eee;padding: 0 0 10px 0;overflow:auto;font-family:'Andale Mono','Courier New',monospace;font-size:9pt;">},
+                          qq{<span style="display:block;padding:0 10px;">\n<span class="info" style="display:block;padding:0 10px;color:#888;background:#fff;">}) )  ;
                 $in_div = 1;
                 print $out encode_entities($_, '<>&"'), "\n" for ($before, $after);
                 print $out "</span>";
@@ -162,14 +168,17 @@ sub output_diff {
                 # Output the headers.
                 print $out "</$in_span>" if $in_span;
                 print $out "</span></pre></div>\n" if $in_div;
-                print $out qq{<a id="$id"></a>\n<div class="propset">},
-                  qq{<h4>Property changes: $file</h4>\n<pre class="diff"><span>\n};
+                print $out ( ( qq{<a id="$id"></a>\n<div class="propset" style="border:1px solid #ccc;margin:10px 0;">},
+					  qq{<h4 style="font-family: verdana,arial,helvetica,sans-serif;font-size:10pt;padding:8px;background:#369;color:#fff;margin:0;">},
+					  qq{Property changes: $file</h4>\n},
+					  qq{<pre class="diff" style="color:black;padding:0;line-height:1.2em;margin:0;width:100%;background:#eee;padding: 0 0 10px 0;overflow:auto;font-family:'Andale Mono','Courier New',monospace;font-size:9pt;">},
+					  qq{<span style="display:block;padding:0 10px;">\n}) );
                 $in_div = 1;
                 $in_span = '';
             } elsif ($line =~ /^\@\@/) {
                 print $out "</$in_span>" if $in_span;
                 print $out (
-                    qq{<span class="lines">},
+                    ( qq{<span class="lines" style="display:block;padding:0 10px;color:#888;background:#fff;">} ),
                     encode_entities($line, '<>&"'),
                     "\n</span>",
                 );
@@ -179,9 +188,10 @@ sub output_diff {
                 if ($in_span eq $type) {
                     print $out encode_entities($line, '<>&"'), "\n";
                 } else {
+                    my $clr = $type eq 'ins' ? '#dfd' : '#fdd';
                     print $out "</$in_span>" if $in_span;
                     print $out (
-                        qq{<$type>},
+                        ( qq{<$type style="background-color:$clr;text-decoration:none;display:block;padding:0 10px;">} ),
                         encode_entities($line, '<>&"'),
                         "\n",
                     );
@@ -193,7 +203,7 @@ sub output_diff {
                 } else {
                     print $out "</$in_span>" if $in_span;
                     print $out (
-                        qq{<span class="cx">},
+                        ( qq{<span class="cx" style="display:block;padding:0 10px;">} ),
                         encode_entities($line, '<>&"'),
                         "\n",
                     );

--- a/t/alt.t
+++ b/t/alt.t
@@ -137,7 +137,7 @@ like $email, qr{^Modified: trunk/Params-CallbackRequest/Changes}m,
     'The diff should be embedded in the HTML mesage';
 
 like $email,
-    qr{^<div class="modfile"><h4>Modified: trunk/Params-CallbackRequest/Changes}m,
+    qr{^<div class="modfile" style="border:1px solid #ccc;margin:10px 0;"><h4 style="font-family: verdana,arial,helvetica,sans-serif;font-size:10pt;padding:8px;background:#369;color:#fff;margin:0;">Modified: trunk/Params-CallbackRequest/Changes}m,
     'The diff should be embedded in the HTML message';
 
 ##############################################################################
@@ -174,11 +174,11 @@ like $email, qr{^Modified: trunk/Params-CallbackRequest/Changes}m,
     'The diff should be embedded in the HTML mesage';
 
 like $email,
-    qr{^<div class="modfile"><h4>Modified: trunk/Params-CallbackRequest/Changes}m,
+    qr{^<div class="modfile" style="border:1px solid #ccc;margin:10px 0;"><h4 style="font-family: verdana,arial,helvetica,sans-serif;font-size:10pt;padding:8px;background:#369;color:#fff;margin:0;">Modified: trunk/Params-CallbackRequest/Changes}m,
     'The diff should be embedded in the HTML message';
 
 like $email,
-    qr{^<div class="modfile"><h4>Modified: trunk/Params-CallbackRequest/Changes}m,
+    qr{^<div class="modfile" style="border:1px solid #ccc;margin:10px 0;"><h4 style="font-family: verdana,arial,helvetica,sans-serif;font-size:10pt;padding:8px;background:#369;color:#fff;margin:0;">Modified: trunk/Params-CallbackRequest/Changes}m,
     'The diff should be embedded in the HTML::ColorDiff message';
 
 ##############################################################################

--- a/t/filter.t
+++ b/t/filter.t
@@ -147,7 +147,7 @@ SKIP: {
     ok $notifier->prepare, 'Prepare log_message filter checking';
     ok $notifier->execute, 'Notify log_mesage filter checking';
     $email = get_output();
-    like $email, qr/<div id="msg">\nIn the beginning[.]{3}/m,
+    like $email, qr/<div id="msg" style="color:black;">\nIn the beginning[.]{3}/m,
         'Start text should be present';
     like $email, qr{</html>\nThe end[.]}m, 'End text should be present';
 

--- a/t/html.t
+++ b/t/html.t
@@ -93,16 +93,16 @@ for my $header ('Log Message', 'Modified Paths', 'Added Paths',
 }
 
 # Check that we have the commit metatdata.
-like( $email, qr|<dt>Revision</dt> <dd><a href="http://foo[.]com/111">111</a></dd>\n|, 'Check Revision');
-like( $email, qr|<dt>Author</dt> <dd>theory</dd>\n|, 'Check Author');
+like( $email, qr|<dt style="float: left; width: 6em; font-weight: bold;font-family: verdana,arial,helvetica,sans-serif; font-size: 10pt;">Revision:</dt> <dd><a href="http://foo[.]com/111">111</a></dd>\n|, 'Check Revision');
+like( $email, qr|<dt style="float: left; width: 6em; font-weight: bold;font-family: verdana,arial,helvetica,sans-serif; font-size: 10pt;">Author:</dt> <dd>theory</dd>\n|, 'Check Author');
 like( $email,
-      qr|<dt>Date</dt> <dd>2004-04-20 01:33:35 -0700 \(Tue, 20 Apr 2004\)</dd>\n|,
+      qr|<dt style="float: left; width: 6em; font-weight: bold;font-family: verdana,arial,helvetica,sans-serif; font-size: 10pt;">Date:</dt> <dd>2004-04-20 01:33:35 -0700 \(Tue, 20 Apr 2004\)</dd>\n|,
       'Check Date');
 
 # Check that the log message is there.
 UTF8: {
     use utf8;
-    like( $email, qr{<pre>Did this, that, and the «other»\. And then I did some more\. Some\nit was done on a second line\. “Go figure”\. <a href="http://foo[.]com/1234">r1234</a></pre>}, 'Check for HTML log message' );
+    like( $email, qr{<pre style="overflow: auto; background: #ffc; border: 1px #fa0 solid; padding: 6px;">Did this, that, and the «other»\. And then I did some more\. Some\nit was done on a second line\. “Go figure”\. <a href="http://foo[.]com/1234">r1234</a></pre>}, 'Check for HTML log message' );
 }
 
 # Make sure that Class/Meta.pm is listed twice, once for modification and once
@@ -307,7 +307,7 @@ ok( $notifier->execute, "Notify HTML viewcvs_url" );
 # Check the output.
 $email = get_output();
 like( $email,
-      qr|<dt>Revision</dt>\s+<dd><a href="http://svn\.example\.com/\?rev=111\&amp;view=rev">111</a></dd>\n|,
+      qr|<dt style="float: left; width: 6em; font-weight: bold;font-family: verdana,arial,helvetica,sans-serif; font-size: 10pt;">Revision:</dt>\s+<dd><a style="color: white;font-weight: bold;" href="http://svn\.example\.com/\?rev=111\&amp;view=rev">111</a></dd>\n|,
       'Check for HTML URL');
 
 ##############################################################################
@@ -386,25 +386,25 @@ like($email,
 
 # Check for application URLs.
 like( $email,
-      qr|<dt>Revision</dt>\s+<dd><a href="http://viewsvn\.bricolage\.cc/\?rev=222\&amp;view=rev">222</a></dd>\n|,
+      qr|<dt style="float: left; width: 6em; font-weight: bold;font-family: verdana,arial,helvetica,sans-serif; font-size: 10pt;">Revision:</dt>\s+<dd><a style="color: white;font-weight: bold;" href="http://viewsvn\.bricolage\.cc/\?rev=222\&amp;view=rev">222</a></dd>\n|,
       'Check for main ViewCVS URL');
 like($email,
      qr{<a href="http://rt\.cpan\.org/NoAuth/Bugs\.html\?id=4321">Ticket # 4321</a>},
      "Check for RT URL");
 like($email,
-     qr{<a href="http://viewsvn\.bricolage\.cc/\?rev=606&amp;view=rev">Revision # 606</a>},
+     qr{<a style="color: white;font-weight: bold;" href="http://viewsvn\.bricolage\.cc/\?rev=606&amp;view=rev">Revision # 606</a>},
      "Check for log mesage ViewCVS URL");
 like( $email,
-      qr{<a href="http://bugzilla\.mozilla\.org/show_bug\.cgi\?id=709">Bug # 709</a>},
+      qr{<a style="color: white;font-weight: bold;" href="http://bugzilla\.mozilla\.org/show_bug\.cgi\?id=709">Bug # 709</a>},
       "Check for Bugzilla URL" );
 like( $email,
-      qr{<a href="http://jira\.atlassian\.com/secure/ViewIssue\.jspa\?key=PRJ1234-111">PRJ1234-111</a>},
+      qr{<a style="color: white;font-weight: bold;" href="http://jira\.atlassian\.com/secure/ViewIssue\.jspa\?key=PRJ1234-111">PRJ1234-111</a>},
       "Check for Jira URL" );
 like( $email,
-      qr{<a href="http://gnats\.example\.com/gnatsweb\.pl\?cmd=view&amp;pr=12345">PR 12345</a>},
+      qr{<a style="color: white;font-weight: bold;" href="http://gnats\.example\.com/gnatsweb\.pl\?cmd=view&amp;pr=12345">PR 12345</a>},
       "Check for GNATS URL" );
 like( $email,
-      qr{<a href="http://ticket\.example\.com/id=4321">Custom # 4321</a>},
+      qr{<a style="color: white;font-weight: bold;" href="http://ticket\.example\.com/id=4321">Custom # 4321</a>},
       "Check for custom ticket URL" );
 
 ##############################################################################
@@ -460,7 +460,7 @@ like($email,
 
 # Check for ViewCVS URLs.
 like( $email,
-      qr|<dt>Revision</dt>\s+<dd><a href="http://viewsvn\.bricolage\.cc/\?rev=444\&amp;view=rev">444</a></dd>\n|,
+      qr|<dt style="float: left; width: 6em; font-weight: bold;font-family: verdana,arial,helvetica,sans-serif; font-size: 10pt;">Revision:</dt>\s+<dd><a style="color: white;font-weight: bold;" href="http://viewsvn\.bricolage\.cc/\?rev=444\&amp;view=rev">444</a></dd>\n|,
       'Check for main ViewCVS URL');
 like($email,
      qr{<a href="http://viewsvn\.bricolage\.cc/\?rev=6000&amp;view=rev">Revision 6000</a>\.},
@@ -523,7 +523,7 @@ like($email, qr/link\.\n\nWe/, "Check for multiple lines" );
 
 # Check for SVNWeb URLs.
 like( $email,
-      qr|<dt>Revision</dt>\s+<dd><a href="http://svn\.example\.com/index\.cgi/revision/\?rev=444">444</a></dd>\n|,
+      qr|<dt style="float: left; width: 6em; font-weight: bold;font-family: verdana,arial,helvetica,sans-serif; font-size: 10pt;">Revision:</dt>\s+<dd><a style="color: white;font-weight: bold;" href="http://svn\.example\.com/index\.cgi/revision/\?rev=444">444</a></dd>\n|,
       'Check for main SVNWeb URL');
 like($email,
      qr{<a href="http://svn\.example\.com/index\.cgi/revision/\?rev=6000">Revision 6000</a>\.},
@@ -553,7 +553,7 @@ $email = get_output();
 
 # Check for Author URL.
 like( $email,
-      qr|<dt>Author</dt>\s+<dd><a href="http://svn\.example\.com/~theory/">theory</a></dd>\n|,
+      qr|<dt style="float: left; width: 6em; font-weight: bold;font-family: verdana,arial,helvetica,sans-serif; font-size: 10pt;">Author:</dt>\s+<dd><a href="http://svn\.example\.com/~theory/">theory</a></dd>\n|,
       'Check for Author URL');
 
 ##############################################################################
@@ -578,7 +578,7 @@ like $email, qr{<div id="header">This is the &amp;header</div>\n<dl class="meta"
       'Check for the header';
 
 like $email,
-    qr{<div id="footer">This is the &amp;footer</div>\s+</div>\s+</body>},
+    qr{<div id="footer" style="color: #fff; background: #636; border: 1px #300 solid; padding: 6px;font-family: verdana,arial,helvetica,sans-serif; font-size: 10pt; ">This is the &amp;footer</div>\s+</div>\s+</body>},
     'Check for the footer';
 
 ##############################################################################
@@ -603,7 +603,7 @@ like $email, qr{<div id="header"><p>&laquo;Welcome!&raquo;</p></div>\n<dl class=
       'Check for the header';
 
 like $email,
-    qr{<div id="footer"><p>Copyright &reg; 2006</p></div>\s+</div>\s+</body>},
+    qr{<div id="footer" style="color: #fff; background: #636; border: 1px #300 solid; padding: 6px;font-family: verdana,arial,helvetica,sans-serif; font-size: 10pt; "><p>Copyright &reg; 2006</p></div>\s+</div>\s+</body>},
     'Check for the footer';
 
 ##############################################################################

--- a/t/html.t
+++ b/t/html.t
@@ -84,7 +84,7 @@ like( $email, qr/<\/style>/, "Check for </style> tag" );
 like( $email,
       qr/#msg dl.meta { border: 1px #006 solid; background: #369; padding: 6px; color: #fff; }/,
       "Check for style" );
-like( $email, qr/<div id="msg">/, "Check for msg div" );
+like( $email, qr/<div id="msg" style="color:black;">/, "Check for msg div" );
 
 # Make sure we have headers for each of the four kinds of changes.
 for my $header ('Log Message', 'Modified Paths', 'Added Paths',

--- a/t/htmlcolordiff.t
+++ b/t/htmlcolordiff.t
@@ -70,7 +70,7 @@ like( $email, qr/<\/style>/, "Check for </style> tag" );
 like( $email,
       qr/#patch ins {background:#dfd;text-decoration:none;display:block;padding:0 10px;}/,
       'Check for style' );
-like( $email, qr/<div id="msg">/, "Check for msg div" );
+like( $email, qr/<div id="msg" style="color:black;">/, "Check for msg div" );
 
 # Make sure we have headers for each of the four kinds of changes.
 for my $header ('Log Message', 'Modified Paths', 'Added Paths',
@@ -154,7 +154,7 @@ is( scalar @{[$email =~ m{Content-Transfer-Encoding: 8bit\n}g]}, 1,
 like( $email, qr/<div id="patch">/, "Check for patch div" );
 like( $email, qr{<a id="trunkParamsCallbackRequestChanges"></a>\n},
       "Check for file div ID");
-like( $email, qr{<div class="modfile"><h4>Modified: trunk/Params-CallbackRequest/Changes \(600 => 601\)</h4>},
+like( $email, qr{<div class="modfile" style="border:1px solid #ccc;margin:10px 0;"><h4 style="font-family: verdana,arial,helvetica,sans-serif;font-size:10pt;padding:8px;background:#369;color:#fff;margin:0;">Modified: trunk/Params-CallbackRequest/Changes \(600 => 601\)</h4>},
       "Check for diff file header" );
 like( $email, qr{<a id="trunkParamsCallbackRequestlibParamsCallbackpm"></a>\n},
       "Check for added file div ID");
@@ -348,7 +348,7 @@ like( $email, qr{Content-Transfer-Encoding: 8bit\n},
 # Check for a header for the modified file.
 like( $email, qr{<a id="trunkactivitymailbinactivitymail"></a>\n},
       "Check for modified file div ID");
-like( $email, qr{<div class="modfile"><h4>Modified: trunk/activitymail/bin/activitymail \(681 => 682\)</h4>},
+like( $email, qr{<div class="modfile" style="border:1px solid #ccc;margin:10px 0;"><h4 style="font-family: verdana,arial,helvetica,sans-serif;font-size:10pt;padding:8px;background:#369;color:#fff;margin:0;">Modified: trunk/activitymail/bin/activitymail \(681 => 682\)</h4>},
       "Check for modified file header" );
 
 # Check for propset file.

--- a/t/htmlcolordiff.t
+++ b/t/htmlcolordiff.t
@@ -79,16 +79,16 @@ for my $header ('Log Message', 'Modified Paths', 'Added Paths',
 }
 
 # Check that we have the commit metatdata.
-like( $email, qr|<dt>Revision</dt> <dd>111</dd>\n|, 'Check Revision');
-like( $email, qr|<dt>Author</dt> <dd>theory</dd>\n|, 'Check Author');
+like( $email, qr|<dt style="float: left; width: 6em; font-weight: bold;font-family: verdana,arial,helvetica,sans-serif; font-size: 10pt;">Revision:</dt> <dd>111</dd>\n|, 'Check Revision');
+like( $email, qr|<dt style="float: left; width: 6em; font-weight: bold;font-family: verdana,arial,helvetica,sans-serif; font-size: 10pt;">Author:</dt> <dd>theory</dd>\n|, 'Check Author');
 like( $email,
-      qr|<dt>Date</dt> <dd>2004-04-20 01:33:35 -0700 \(Tue, 20 Apr 2004\)</dd>\n|,
+      qr|<dt style="float: left; width: 6em; font-weight: bold;font-family: verdana,arial,helvetica,sans-serif; font-size: 10pt;">Date:</dt> <dd>2004-04-20 01:33:35 -0700 \(Tue, 20 Apr 2004\)</dd>\n|,
       'Check Date');
 
 # Check that the log message is there.
 UTF8: {
     use utf8;
-    like( $email, qr{<pre>Did this, that, and the «other»\. And then I did some more\. Some\nit was done on a second line\. “Go figure”\. r1234</pre>}, 'Check for HTML log message' );
+    like( $email, qr{<pre style="overflow: auto; background: #ffc; border: 1px #fa0 solid; padding: 6px;">Did this, that, and the «other»\. And then I did some more\. Some\nit was done on a second line\. “Go figure”\. r1234</pre>}, 'Check for HTML log message' );
 }
 
 # Make sure that Class/Meta.pm is listed twice, once for modification and once
@@ -158,11 +158,11 @@ like( $email, qr{<div class="modfile" style="border:1px solid #ccc;margin:10px 0
       "Check for diff file header" );
 like( $email, qr{<a id="trunkParamsCallbackRequestlibParamsCallbackpm"></a>\n},
       "Check for added file div ID");
-like( $email, qr{<div class="addfile"><h4>Added: trunk/Params-CallbackRequest/lib/Params/Callback.pm \(600 => 601\)</h4>},
+like( $email, qr{<div class="addfile" style="border:1px solid #ccc;margin:10px 0;"><h4 style="font-family: verdana,arial,helvetica,sans-serif;font-size:10pt;padding:8px;background:#369;color:#fff;margin:0;">Added: trunk/Params-CallbackRequest/lib/Params/Callback.pm \(600 => 601\)</h4>},
       "Check for added diff file header" );
-like( $email, qr{<ins>\+    \{ isa        =&gt; \$ap_req_class,\n</ins>},
+like( $email, qr{<ins style="background-color:#dfd;text-decoration:none;display:block;padding:0 10px;">\+    \{ isa        =&gt; \$ap_req_class,\n</ins>},
       'Check for an insert element.');
-like( $email, qr{<del>-    \{ isa        =&gt; ('|&#39;)Apache\1,\n</del>},
+like( $email, qr{<del style="background-color:#fdd;text-decoration:none;display:block;padding:0 10px;">-    \{ isa        =&gt; ('|&#39;)Apache\1,\n</del>},
       'Check for a del element');
 
 # Make sure that it's not attached.
@@ -202,7 +202,7 @@ ok( $notifier->execute, 'HTML diff_switches notify' );
 $email = get_output();
 
 like $email,
-    qr{<div class="addfile"><h4>Added:\s+trunk/Params-CallbackRequest/lib/Params/Callback\.pm</h4></div>\n</div>\s+</body>},
+    qr{<div class="addfile" style="border:1px solid #ccc;margin:10px 0;"><h4 style="font-family: verdana,arial,helvetica,sans-serif;font-size:10pt;padding:8px;background:#369;color:#fff;margin:0;">Added:\s+trunk/Params-CallbackRequest/lib/Params/Callback\.pm</h4></div>\n</div>\s+</body>},
     'Check for added diff file header without body';
 
 ##############################################################################
@@ -284,7 +284,7 @@ ok( $notifier->execute, "Notify HTML viewcvs_url" );
 # Check the output.
 $email = get_output();
 like( $email,
-      qr|<dt>Revision</dt>\s+<dd><a href="http://svn\.example\.com/\?rev=111\&amp;view=rev">111</a></dd>\n|,
+      qr|<dt style="float: left; width: 6em; font-weight: bold;font-family: verdana,arial,helvetica,sans-serif; font-size: 10pt;">Revision:</dt>\s+<dd><a style="color: white;font-weight: bold;" href="http://svn\.example\.com/\?rev=111\&amp;view=rev">111</a></dd>\n|,
       'Check for HTML URL');
 
 ##############################################################################
@@ -302,7 +302,7 @@ ok( $notifier->execute, "Notify HTML svnweb_url" );
 # Check the output.
 $email = get_output();
 like( $email,
-      qr|<dt>Revision</dt>\s+<dd><a href="http://svn\.example\.com/\?rev=111\&amp;view=rev">111</a></dd>\n|,
+      qr|<dt style="float: left; width: 6em; font-weight: bold;font-family: verdana,arial,helvetica,sans-serif; font-size: 10pt;">Revision:</dt>\s+<dd><a style="color: white;font-weight: bold;" href="http://svn\.example\.com/\?rev=111\&amp;view=rev">111</a></dd>\n|,
       'Check for HTML URL');
 
 ##############################################################################
@@ -354,7 +354,7 @@ like( $email, qr{<div class="modfile" style="border:1px solid #ccc;margin:10px 0
 # Check for propset file.
 like( $email, qr{<a id="trunkactivitymailbinactivitymail"></a>\n},
       "Check for modified file div ID");
-like( $email, qr{<div class="propset"><h4>Property changes: trunk/activitymail/t/activitymail\.t</h4>},
+like( $email, qr{<div class="propset" style="border:1px solid #ccc;margin:10px 0;"><h4 style="font-family: verdana,arial,helvetica,sans-serif;font-size:10pt;padding:8px;background:#369;color:#fff;margin:0;">Property changes: trunk/activitymail/t/activitymail\.t</h4>},
       "Check for modified file header" );
 
 ##############################################################################
@@ -378,7 +378,7 @@ like($email, qr/link\.\n\nWe/, "Check for multiple lines" );
 
 # Check for SVNWeb URLs.
 like( $email,
-      qr|<dt>Revision</dt>\s+<dd><a href="http://svn\.example\.com/index\.cgi/revision/\?rev=444">444</a></dd>\n|,
+      qr|<dt style="float: left; width: 6em; font-weight: bold;font-family: verdana,arial,helvetica,sans-serif; font-size: 10pt;">Revision:</dt>\s+<dd><a style="color: white;font-weight: bold;" href="http://svn\.example\.com/index\.cgi/revision/\?rev=444">444</a></dd>\n|,
       'Check for main SVNWeb URL');
 like($email,
      qr{<a href="http://svn\.example\.com/index\.cgi/revision/\?rev=6000">Revision 6000</a>\.},
@@ -433,9 +433,9 @@ ok $notifier->execute, 'Notify HTML header and footer checking';
 $email = get_output();
 $email = get_output();
 like( $email,
-      qr{<p>Hey, we could add one for a Subversion Revision # 606, too!</p>
+      qr{<p style="margin: 0 0 1em 0;line-height: 14pt;">Hey, we could add one for a Subversion Revision # 606, too!</p>
 
-<p>And finally, we have RT-Ticket: 123 for Jesse and RT # 445 for Ask\.
+<p style="margin: 0 0 1em 0;line-height: 14pt;">And finally, we have RT-Ticket: 123 for Jesse and RT # 445 for Ask\.
 And we even have Mantis-161: foo bar baz for Dirk Olmes\.</p>},
       'The log message should be in paragraph tags'
 );
@@ -469,7 +469,7 @@ ok( $notifier->execute, "Notify complex example" );
 
 $email = get_output();
 # Make sure multiple lines are paragraphs!
-like($email, qr{link\.</p>\n\n<p>We}, "Check for multiple paragraphs" );
+like($email, qr{link\.</p>\n\n<p style="margin: 0 0 1em 0;line-height: 14pt;">We}, "Check for multiple paragraphs" );
 
 # Make sure we have good unicode characters.
 UTF8: {
@@ -479,12 +479,12 @@ UTF8: {
 
 # Make sure that binary files in the diff are set up properly.
 like($email,
-     qr{<div class="binary"><h4>Deleted: trunk/SVN-Notify/t/data/bin/sendmail\.exe</h4>},
+     qr{<div class="binary" style="border:1px solid #ccc;margin:10px 0;"><h4 style="font-family: verdana,arial,helvetica,sans-serif;font-size:10pt;padding:8px;background:#369;color:#fff;margin:0;">Deleted: trunk/SVN-Notify/t/data/bin/sendmail\.exe</h4>},
      "Check for binary file div");
 
 # Make sure that copied files in the diff are set up properly.
 like($email,
-     qr{<div class="copfile"><h4>Copied: trunk/TestSimple/doc/pod/Test/Builder\.pod \(1634 => 1646\)</h4>},
+     qr{<div class="copfile" style="border:1px solid #ccc;margin:10px 0;"><h4 style="font-family: verdana,arial,helvetica,sans-serif;font-size:10pt;padding:8px;background:#369;color:#fff;margin:0;">Copied: trunk/TestSimple/doc/pod/Test/Builder\.pod \(1634 => 1646\)</h4>},
      "Check for copied file div");
 
 # Check linkize results.
@@ -515,7 +515,7 @@ like($email,
 
 # Check for ViewCVS URLs.
 like( $email,
-      qr|<dt>Revision</dt>\s+<dd><a href="http://viewsvn\.bricolage\.cc/\?rev=444\&amp;view=rev">444</a></dd>\n|,
+      qr|<dt style="float: left; width: 6em; font-weight: bold;font-family: verdana,arial,helvetica,sans-serif; font-size: 10pt;">Revision:</dt>\s+<dd><a style="color: white;font-weight: bold;" href="http://viewsvn\.bricolage\.cc/\?rev=444\&amp;view=rev">444</a></dd>\n|,
       'Check for main ViewCVS URL');
 like($email,
      qr{<a href="http://viewsvn\.bricolage\.cc/\?rev=6000&amp;view=rev">Revision 6000</a>\.},
@@ -524,7 +524,7 @@ like($email,
      qr{<a href="http://viewsvn\.bricolage\.cc/\?rev=6001&amp;view=rev">rev\n6001</a>\.},
      "Check for split line log mesage ViewCVS URL");
 unlike($email,
-       qr{<a href="http://viewsvn\.bricolage\.cc/\?rev=200&amp;view=rev">rev 200</a>,},
+       qr{<a style="color: white;font-weight: bold;" href="http://viewsvn\.bricolage\.cc/\?rev=200&amp;view=rev">rev 200</a>,},
        "Check for no grev 200 ViewCVS URL");
 
 # Check for Bugzilla URLs.
@@ -557,7 +557,7 @@ like( $email,
       qr{<a href="http://ticket\.example\.com/id=54321">Custom # 54321</a>},
       "Check for custom ticket URL" );
 
-unlike $email, qr{<p></p>}, 'There should be no empty paragraphs';
+unlike $email, qr{<p style="margin: 0 0 1em 0;line-height: 14pt;"></p>}, 'There should be no empty paragraphs';
 
 ##############################################################################
 # Functions.


### PR DESCRIPTION
I have been able to rebase the patches from @fgiust to get the inline css working.   This makes the html emails look good in gmail.

It seems to work however I'm not able to get the tests passing due to some UTF8 Errors.  I'm using this patched version without issue so far.  If someone can help fix up the tests, I think this is a great contribution to the module.
