### PR TITLE
Account for non-glob stash entries

### DIFF
--- a/lib/SVN/Notify.pm
+++ b/lib/SVN/Notify.pm
@@ -708,7 +708,9 @@ sub new {
                 $filters{$pkg} = {};
                 no strict 'refs';
                 while ( my ($k, $v) = each %{ "$pkg\::" } ) {
-                    my $code = *{$v}{CODE} or next;
+                    my $code = ref \$v eq 'GLOB' ? *{$v}{CODE}
+                             : ref  $v eq 'CODE' ? $v
+                             : *{ "$pkg\::$k" }{CODE} or next;
                     $filters{$pkg}->{$k} = $code;
                     $filts->{$k} ||= [];
                     push @{ $filts->{$k} }, $code;


### PR DESCRIPTION
In bleadperl (5.28-to-be), a sub may be stored as a simple code ref in
the stash.  Even in existing stable releases of perl, stash entries
are not always typeglobs.  Constants created by ‘use constant’, for
instance, are stored as scalar refs.  This patch takes all these into
account, but does not add any tests, since I am not sure how to trig-
ger this code path with a constant.  Nevertheless, before this, the
tests failed with bleadperl.