### PR TITLE
Change from Email::Address, which is marked as deprecated, to the com…

### DIFF
--- a/lib/SVN/Notify.pm
+++ b/lib/SVN/Notify.pm
@@ -1471,10 +1471,10 @@ sub output_headers {
     # Q-Encode the phrase part of recipient headers.
     my $norm;
     if (PERL58) {
-        require Email::Address;
+        require Email::Address::XS;
         $norm = sub {
             return join ', ' => map {
-                my ($addr) = Email::Address->parse($_);
+                my ($addr) = Email::Address::XS->parse($_);
                 if ($addr) {
                     if (my $phrase = $addr->phrase) {
                         $addr->phrase(Encode::encode( 'MIME-Q', $phrase ));


### PR DESCRIPTION
Change from Email::Address, which is marked as deprecated, to the compatible Email::Address::XS.
https://github.com/Perl-Email-Project/Email-Address/commit/fcc869adf7a22d92bfc13283950b5604c532b3fe