### PR TITLE
Use is_valid() to test addresses.  Previously, using Email::Address, …

### DIFF
--- a/lib/SVN/Notify.pm
+++ b/lib/SVN/Notify.pm
@@ -1474,8 +1474,8 @@ sub output_headers {
         require Email::Address::XS;
         $norm = sub {
             return join ', ' => map {
-                my ($addr) = Email::Address::XS->parse($_);
-                if ($addr) {
+                my $addr = Email::Address::XS->parse($_);
+                if ($addr->is_valid()) {
                     if (my $phrase = $addr->phrase) {
                         $addr->phrase(Encode::encode( 'MIME-Q', $phrase ));
                     }


### PR DESCRIPTION
…$addr was undefined if no object was parsed. Now, using Email::Address:XS (since version 1.01), an empty Email::Address::XS object is returned.